### PR TITLE
Add bulk thread scraping script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ TG_API_HASH=
 TG_CHANNELS=        # comma-separated: @group1,@group2
 N8N_WEBHOOK_URL=
 
+# ID першого повідомлення теми (thread), наприклад з посилання https://t.me/<channel>/<MSG_ID>/<THREAD_ID>
+THREAD_MESSAGE_ID=
+
 HTTP_TIMEOUT=10
 HTTP_MAX_RETRIES=5
 HTTP_BACKOFF_SECONDS=2

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ pip install -r requirements.txt
 python -m telegram_scraper.run
 ```
 
+## Експорт усіх повідомлень із теми (thread)
+
+1. Вкажіть `THREAD_MESSAGE_ID` у `.env` (наприклад `THREAD_MESSAGE_ID=418`).
+2. Запустіть одноразовий експорт:
+
+   ```bash
+   docker compose run --rm telegram-scraper python -m telegram_scraper.scrape_thread
+   ```
+
 ## Updating
 
 Pull the latest changes and rebuild:

--- a/telegram_scraper/config.py
+++ b/telegram_scraper/config.py
@@ -20,6 +20,7 @@ class Config:
     log_level: str
     state_backend: str
     state_file: str
+    thread_message_id: int | None
 
 
 def _require(name: str) -> str:
@@ -35,6 +36,9 @@ def load_config(env_file: str = ".env") -> Config:
 
     channels = [c.strip().lstrip("@") for c in _require("TG_CHANNELS").split(",") if c.strip()]
 
+    thread_env = os.getenv("THREAD_MESSAGE_ID")
+    thread_message_id = int(thread_env) if thread_env else None
+
     return Config(
         api_id=int(_require("TG_API_ID")),
         api_hash=_require("TG_API_HASH"),
@@ -46,4 +50,5 @@ def load_config(env_file: str = ".env") -> Config:
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         state_backend=os.getenv("STATE_BACKEND", "file"),
         state_file=os.getenv("STATE_FILE", ".state.json"),
+        thread_message_id=thread_message_id,
     )

--- a/telegram_scraper/scrape_thread.py
+++ b/telegram_scraper/scrape_thread.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+from typing import AsyncIterator
+
+from telethon.tl.types import Message
+
+from .client import get_client
+from .config import Config, load_config
+from .sender import send_to_n8n
+from .utils import sanitize_text, setup_logging
+
+log = logging.getLogger(__name__)
+
+
+async def iter_thread_messages(client, chat: str, thread_msg_id: int) -> AsyncIterator[Message]:
+    async for m in client.iter_messages(chat, reply_to=thread_msg_id, reverse=True):
+        yield m
+
+
+async def scrape_thread(config: Config) -> None:
+    if not config.thread_message_id:
+        raise ValueError("THREAD_MESSAGE_ID is not set; please add it to .env")
+
+    async with get_client(config.api_id, config.api_hash) as client:
+        for chat in config.channels:
+            log.info(f"scraping thread {config.thread_message_id} in {chat}")
+            async for msg in iter_thread_messages(client, chat, config.thread_message_id):
+                data = {
+                    "group": chat.lstrip("@"),
+                    "author_id": msg.sender_id,
+                    "content": sanitize_text(msg.text or ""),
+                    "date": msg.date.strftime("%Y-%m-%d %H:%M:%S") if msg.date else "",
+                    "message_id": msg.id,
+                    "author": getattr(msg, "post_author", None),
+                    "views": getattr(msg, "views", None),
+                    "reactions": " ".join(
+                        f"{r.emoticon} {r.count}" for r in getattr(msg.reactions, "results", [])
+                    ),
+                    "shares": getattr(msg, "forwards", None),
+                    "media": bool(msg.media),
+                    "url": f"https://t.me/{chat.lstrip('@')}/{msg.id}",
+                    "comments_list": [],
+                    "thread_message_id": config.thread_message_id,
+                    "mode": "bulk_thread_export",
+                }
+                send_to_n8n(data, config)
+            log.info(f"done thread {config.thread_message_id} in {chat}")
+
+
+def main() -> None:
+    config = load_config()
+    setup_logging(config.log_level)
+    asyncio.run(scrape_thread(config))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support optional `THREAD_MESSAGE_ID` config value
- add CLI script to export entire Telegram thread to n8n
- document thread export usage and env var

## Testing
- `TG_API_ID=1 TG_API_HASH=abc TG_CHANNELS=@test N8N_WEBHOOK_URL=https://example.com python -m telegram_scraper.scrape_thread` *(fails: THREAD_MESSAGE_ID is not set; please add it to .env)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e1e92da8832e96b1b60fc66ac658