### PR TITLE
Add delay option to thread scraper webhook sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ python -m telegram_scraper.run
 2. Запустіть одноразовий експорт:
 
    ```bash
-   docker compose run --rm telegram-scraper python -m telegram_scraper.scrape_thread
+   docker compose run --rm telegram-scraper python -m telegram_scraper.scrape_thread --delay 5
    ```
+
+   Параметр `--delay` задає затримку між відправкою повідомлень на вебхук (у секундах).
+   За замовчуванням використовується 3 секунди.
 
 ## Updating
 


### PR DESCRIPTION
## Summary
- allow configuring delay between messages with `--delay` (default 3s)
- document optional `--delay` parameter in README

## Testing
- `pytest -q`
- `python -m telegram_scraper.scrape_thread --help`
- `python -m telegram_scraper.scrape_thread --delay 1` *(fails: ValueError: Environment variable TG_CHANNELS is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e944974c832ea98c495588bddc2e