### PR TITLE
Handle Telethon reactions without emoticon

### DIFF
--- a/telegram_scraper/events.py
+++ b/telegram_scraper/events.py
@@ -41,8 +41,10 @@ def register_handlers(client, config: Config) -> None:
             "message_id": msg.id,
             "author": msg.post_author,
             "views": msg.views,
+            # ReactionCount stores the emoji in r.reaction.emoticon when available
             "reactions": " ".join(
-                f"{r.emoticon} {r.count}" for r in getattr(msg.reactions, "results", [])
+                f"{getattr(r.reaction, 'emoticon', str(r.reaction))} {r.count}"
+                for r in getattr(msg.reactions, "results", [])
             ),
             "shares": msg.forwards,
             "media": msg.media is not None,

--- a/telegram_scraper/scrape_thread.py
+++ b/telegram_scraper/scrape_thread.py
@@ -34,8 +34,10 @@ async def scrape_thread(config: Config, delay: float) -> None:
                     "message_id": msg.id,
                     "author": getattr(msg, "post_author", None),
                     "views": getattr(msg, "views", None),
+                    # ReactionCount stores the emoji in r.reaction.emoticon when available
                     "reactions": " ".join(
-                        f"{r.emoticon} {r.count}" for r in getattr(msg.reactions, "results", [])
+                        f"{getattr(r.reaction, 'emoticon', str(r.reaction))} {r.count}"
+                        for r in getattr(msg.reactions, "results", [])
                     ),
                     "shares": getattr(msg, "forwards", None),
                     "media": bool(msg.media),


### PR DESCRIPTION
## Summary
- Avoid AttributeError when reading Telethon reactions by grabbing reaction info from `r.reaction` and falling back to `str(r.reaction)`
- Document why ReactionCount needs extra getattr wrapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2f22da3d4832ea2155c861eab7f49