### PR TITLE
Send all media in single webhook request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ STATE_FILE=./data/.state.json
 MEDIA_DOWNLOAD=1
 MEDIA_DIR=./data/media
 MEDIA_MAX_MB=50
-MEDIA_SEND_MODE=multipart  # multipart|json
+MEDIA_SEND_MODE=multipart  # multipart: one POST with payload+files[]; json: metadata only

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ python -m telegram_scraper.run
 - `MEDIA_MAX_MB` – максимальний розмір файлу в мегабайтах.
 - `MEDIA_SEND_MODE` – `multipart` або `json`.
 
-У режимі `multipart` кожен файл надсилається окремим POST-запитом до n8n.
-Вузол Webhook отримує бінарні дані у полі `file`, а метадані повідомлення – у полі `payload` (JSON).
+У режимі `multipart` для кожного повідомлення виконується один POST-запит:
+формується поле `payload` з JSON-рядком метаданих та масив `files[]` з усіма
+медіафайлами. У n8n Webhook слід увімкнути binary-режим і читати файли з
+`files[]`, а JSON діставати з поля `payload` (наприклад,
+`JSON.parse($binary.payload.data.toString())`).
 
 Приклад для bulk-експорту:
 

--- a/telegram_scraper/media.py
+++ b/telegram_scraper/media.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import AsyncIterator, Dict, Optional
+from typing import AsyncIterator, Dict, List, Optional, Tuple
 
 from telethon.tl.custom.message import Message
 
@@ -61,3 +61,13 @@ async def iter_media_items(
     meta = await download_one(client, msg, download_dir, max_mb)
     if meta:
         yield meta
+
+
+async def download_all_for_message(
+    client, msg: Message, download_dir: str, max_mb: int
+) -> List[Tuple[str, str | None]]:
+    """Download all media for ``msg`` and return list of path/mimetype pairs."""
+    results: List[Tuple[str, str | None]] = []
+    async for meta in iter_media_items(client, msg, download_dir, max_mb):
+        results.append((meta["file_path"], meta.get("mimetype")))
+    return results


### PR DESCRIPTION
## Summary
- add batch sender to send one multipart request with all media files
- collect and transmit all media per message in events and bulk thread scraping
- document new multipart payload with `files[]` and `payload`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a30866390c832eb118064c202f2c72