### PR TITLE
Send payload and media in single multipart request

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,18 @@ python -m telegram_scraper.run
 - `MEDIA_MAX_MB` – максимальний розмір файлу в мегабайтах.
 - `MEDIA_SEND_MODE` – `multipart` або `json`.
 
-У режимі `multipart` для кожного повідомлення виконується один POST-запит:
-формується поле `payload` з JSON-рядком метаданих та масив `files[]` з усіма
-медіафайлами. У n8n Webhook слід увімкнути binary-режим і читати файли з
-`files[]`, а JSON діставати з поля `payload` (наприклад,
-`JSON.parse($binary.payload.data.toString())`).
+У режимі `multipart` для кожного повідомлення відправляється один `POST` із такими полями:
+
+- `payload` — текстове поле з JSON-рядком метаданих;
+- `files[]` — масив усіх медіафайлів.
+
+У n8n Webhook потрібно увімкнути binary-режим. Щоб дістати `payload`, прочитайте його як текст та розпарсіть, наприклад у Function/Set:
+
+```js
+const data = JSON.parse($binary.payload.data.toString());
+```
+
+Файли доступні у масиві `files[]`.
 
 Приклад для bulk-експорту:
 


### PR DESCRIPTION
## Summary
- Use a single multipart POST to upload payload JSON and media files together
- Document multipart mode payload and files[] in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a336066378832eb98c6183e0abb40a