### PR TITLE
Aggregate album messages into single webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,4 @@ MEDIA_DOWNLOAD=1
 MEDIA_DIR=./data/media
 MEDIA_MAX_MB=50
 MEDIA_SEND_MODE=multipart  # multipart: one POST with payload+files[]; json: metadata only
+ALBUM_DEBOUNCE_SEC=2       # seconds to wait for album completion

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ python -m telegram_scraper.run
 - `MEDIA_DIR` – локальна папка для збереження файлів.
 - `MEDIA_MAX_MB` – максимальний розмір файлу в мегабайтах.
 - `MEDIA_SEND_MODE` – `multipart` або `json`.
+- `ALBUM_DEBOUNCE_SEC` – затримка в секундах для збирання альбому перед відправкою.
 
 У режимі `multipart` для кожного повідомлення відправляється один `POST` із такими полями:
 
 - `payload` — текстове поле з JSON-рядком метаданих;
 - `files[]` — масив усіх медіафайлів.
 
-У n8n Webhook потрібно увімкнути binary-режим. Щоб дістати `payload`, прочитайте його як текст та розпарсіть, наприклад у Function/Set:
+У n8n Webhook потрібно увімкнути binary-режим, а поле **Field Name for Binary Data** вказати як `files[]`. Щоб дістати `payload`, прочитайте його як текст та розпарсіть, наприклад у Function/Set:
 
 ```js
 const data = JSON.parse($binary.payload.data.toString());

--- a/telegram_scraper/config.py
+++ b/telegram_scraper/config.py
@@ -25,6 +25,7 @@ class Config:
     media_dir: str
     media_max_mb: int
     media_send_mode: str
+    album_debounce_sec: int
 
 
 def _require(name: str) -> str:
@@ -59,6 +60,7 @@ def load_config(env_file: str = ".env") -> Config:
         media_dir=os.getenv("MEDIA_DIR", "./data/media"),
         media_max_mb=int(os.getenv("MEDIA_MAX_MB", "50")),
         media_send_mode=os.getenv("MEDIA_SEND_MODE", "multipart").lower(),
+        album_debounce_sec=int(os.getenv("ALBUM_DEBOUNCE_SEC", "2")),
     )
 
     os.makedirs(config.media_dir, exist_ok=True)

--- a/telegram_scraper/events.py
+++ b/telegram_scraper/events.py
@@ -1,8 +1,11 @@
 """Telethon event handlers for new messages."""
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Dict, Optional
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from telethon import events
 
@@ -15,10 +18,76 @@ from .utils import format_reaction, sanitize_text
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class AlbumBuffer:
+    """Buffer for collecting album messages until debounce expires."""
+
+    chat: str
+    messages: List
+    last_update: float = field(default_factory=time.time)
+
+
+pending_albums: Dict[int, AlbumBuffer] = {}
+
+
 def register_handlers(client, config: Config) -> None:
     """Register new message handler on the given client."""
     state: Dict[str, int] = load_state(config.state_file)
     target_chats = [f"@{c}" for c in config.channels]
+    async def flush_albums() -> None:
+        while True:
+            now = time.time()
+            to_flush = [
+                gid for gid, buf in pending_albums.items()
+                if now - buf.last_update >= config.album_debounce_sec
+            ]
+            for gid in to_flush:
+                buf = pending_albums.pop(gid)
+                await _process_album(buf)
+            await asyncio.sleep(1)
+
+    async def _process_album(buf: AlbumBuffer) -> None:
+        messages = buf.messages
+        first = messages[0]
+        author_id: Optional[int] = None
+        if getattr(first, "from_id", None) and hasattr(first.from_id, "user_id"):
+            author_id = first.from_id.user_id  # type: ignore[assignment]
+
+        payload = {
+            "group": buf.chat,
+            "author_id": author_id,
+            "content": sanitize_text(first.message),
+            "date": first.date.strftime("%Y-%m-%d %H:%M:%S"),
+            "message_id": first.id,
+            "author": first.post_author,
+            "views": first.views,
+            "reactions": " ".join(
+                format_reaction(r) for r in getattr(first.reactions, "results", [])
+            ),
+            "shares": first.forwards,
+            "media": True,
+            "url": f"https://t.me/{buf.chat}/{first.id}",
+            "comments_list": [],
+            "album_group_id": getattr(first, "grouped_id", None),
+            "has_media": True,
+            "media_count": 0,
+        }
+
+        if config.media_download and config.media_send_mode == "multipart":
+            file_items = []
+            for m in messages:
+                file_items.extend(
+                    await download_all_for_message(
+                        client, m, config.media_dir, config.media_max_mb
+                    )
+                )
+            payload["media_count"] = len(file_items)
+            send_batch_to_n8n(payload, file_items, config)
+        else:
+            payload["media_count"] = len(messages)
+            send_to_n8n(payload, config)
+
+    client.loop.create_task(flush_albums())
 
     @client.on(events.NewMessage(chats=target_chats))
     async def handler(event) -> None:  # type: ignore[override]
@@ -30,6 +99,21 @@ def register_handlers(client, config: Config) -> None:
             return
 
         msg = event.message
+        state[chat_username] = msg.id
+        save_state(config.state_file, state)
+
+        grouped_id = getattr(msg, "grouped_id", None)
+        if grouped_id:
+            buf = pending_albums.get(grouped_id)
+            if buf:
+                buf.messages.append(msg)
+                buf.last_update = time.time()
+            else:
+                pending_albums[grouped_id] = AlbumBuffer(
+                    chat=chat_username, messages=[msg]
+                )
+            return
+
         author_id: Optional[int] = None
         if getattr(msg, "from_id", None) and hasattr(msg.from_id, "user_id"):
             author_id = msg.from_id.user_id  # type: ignore[assignment]
@@ -50,13 +134,10 @@ def register_handlers(client, config: Config) -> None:
             "media": has_media,
             "url": f"https://t.me/{chat_username}/{msg.id}",
             "comments_list": [],
-            "album_group_id": getattr(msg, "grouped_id", None),
+            "album_group_id": None,
             "has_media": has_media,
             "media_count": 0,
         }
-
-        state[chat_username] = msg.id
-        save_state(config.state_file, state)
 
         if (
             config.media_download

--- a/telegram_scraper/scrape_thread.py
+++ b/telegram_scraper/scrape_thread.py
@@ -24,45 +24,74 @@ async def scrape_thread(config: Config, delay: float) -> None:
         raise ValueError("THREAD_MESSAGE_ID is not set; please add it to .env")
 
     async with get_client(config.api_id, config.api_hash) as client:
+        async def _send_group(messages, chat_name):
+            first = messages[0]
+            has_media = any(bool(m.media) for m in messages)
+            data = {
+                "group": chat_name.lstrip("@"),
+                "author_id": first.sender_id,
+                "content": sanitize_text(first.text or ""),
+                "date": first.date.strftime("%Y-%m-%d %H:%M:%S") if first.date else "",
+                "message_id": first.id,
+                "author": getattr(first, "post_author", None),
+                "views": getattr(first, "views", None),
+                "reactions": " ".join(
+                    format_reaction(r) for r in getattr(first.reactions, "results", [])
+                ),
+                "shares": getattr(first, "forwards", None),
+                "media": has_media,
+                "url": f"https://t.me/{chat_name.lstrip('@')}/{first.id}",
+                "comments_list": [],
+                "thread_message_id": config.thread_message_id,
+                "mode": "bulk_thread_export",
+                "album_group_id": getattr(first, "grouped_id", None),
+                "has_media": has_media,
+                "media_count": 0,
+            }
+            if (
+                config.media_download
+                and has_media
+                and config.media_send_mode == "multipart"
+            ):
+                file_items = []
+                for m in messages:
+                    file_items.extend(
+                        await download_all_for_message(
+                            client, m, config.media_dir, config.media_max_mb
+                        )
+                    )
+                data["media_count"] = len(file_items)
+                send_batch_to_n8n(data, file_items, config)
+            else:
+                if has_media:
+                    data["media_count"] = len(messages)
+                send_to_n8n(data, config)
+
         for chat in config.channels:
             log.info(f"scraping thread {config.thread_message_id} in {chat}")
+            current_gid = None
+            pending = []
             async for msg in iter_thread_messages(client, chat, config.thread_message_id):
-                has_media = bool(msg.media)
-                data = {
-                    "group": chat.lstrip("@"),
-                    "author_id": msg.sender_id,
-                    "content": sanitize_text(msg.text or ""),
-                    "date": msg.date.strftime("%Y-%m-%d %H:%M:%S") if msg.date else "",
-                    "message_id": msg.id,
-                    "author": getattr(msg, "post_author", None),
-                    "views": getattr(msg, "views", None),
-                    "reactions": " ".join(
-                        format_reaction(r) for r in getattr(msg.reactions, "results", [])
-                    ),
-                    "shares": getattr(msg, "forwards", None),
-                    "media": has_media,
-                    "url": f"https://t.me/{chat.lstrip('@')}/{msg.id}",
-                    "comments_list": [],
-                    "thread_message_id": config.thread_message_id,
-                    "mode": "bulk_thread_export",
-                    "album_group_id": getattr(msg, "grouped_id", None),
-                    "has_media": has_media,
-                    "media_count": 0,
-                }
-                if (
-                    config.media_download
-                    and has_media
-                    and config.media_send_mode == "multipart"
-                ):
-                    file_items = await download_all_for_message(
-                        client, msg, config.media_dir, config.media_max_mb
-                    )
-                    data["media_count"] = len(file_items)
-                    send_batch_to_n8n(data, file_items, config)
+                gid = getattr(msg, "grouped_id", None)
+                if gid:
+                    if current_gid is None or gid == current_gid:
+                        current_gid = gid
+                        pending.append(msg)
+                        continue
+                    await _send_group(pending, chat)
+                    await asyncio.sleep(delay)
+                    pending = [msg]
+                    current_gid = gid
                 else:
-                    if has_media:
-                        data["media_count"] = 1
-                    send_to_n8n(data, config)
+                    if pending:
+                        await _send_group(pending, chat)
+                        await asyncio.sleep(delay)
+                        pending = []
+                        current_gid = None
+                    await _send_group([msg], chat)
+                    await asyncio.sleep(delay)
+            if pending:
+                await _send_group(pending, chat)
                 await asyncio.sleep(delay)
             log.info(f"done thread {config.thread_message_id} in {chat}")
 

--- a/telegram_scraper/sender.py
+++ b/telegram_scraper/sender.py
@@ -72,7 +72,7 @@ def send_batch_to_n8n(
             if response.ok:
                 logger.info(
                     "sent batch %s with %s file(s) and payload",
-                    data.get("message_id"),
+                    data.get("album_group_id") or data.get("message_id"),
                     len(items),
                 )
                 return


### PR DESCRIPTION
## Summary
- group Telegram album items and forward them in a single webhook call
- support album batching in bulk thread export
- document new `ALBUM_DEBOUNCE_SEC` option and n8n webhook setup

## Testing
- `python -m py_compile telegram_scraper/config.py telegram_scraper/events.py telegram_scraper/scrape_thread.py telegram_scraper/sender.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a35b238acc832eb60b7670c5e984cc